### PR TITLE
Removing dataportal

### DIFF
--- a/source/_data/meta.json
+++ b/source/_data/meta.json
@@ -55,15 +55,6 @@
         "de": "/projects/de",
         "en": "/projects/en"
       }
-    },
-    {
-      "name": "datasets",
-      "title": "Data Page",
-      "navigationTitle": {"de":"Daten","en":"Datasets"},
-      "url": {
-        "de": "https://data.technologiestiftung-berlin.de/",
-        "en": "https://data.technologiestiftung-berlin.de/en"
-      }
     }
   ]
 }

--- a/source/projects/bikerides/de/index.html
+++ b/source/projects/bikerides/de/index.html
@@ -39,7 +39,7 @@ assets:
 
 materialsIncluded:
   - name: "Datensatz"
-    link: "https://https://daten.odis-berlin.de/archive/radverkehrsmengen"
+    link: "https://daten.odis-berlin.de/archive/radverkehrsmengen"
 # if the post had a counterpart on the old site add these tags
 # for redirecting it
 redirect_from:

--- a/source/projects/bikerides/de/index.html
+++ b/source/projects/bikerides/de/index.html
@@ -39,7 +39,7 @@ assets:
 
 materialsIncluded:
   - name: "Datensatz"
-    link: "https://data.technologiestiftung-berlin.de/dataset/radverkehrsmengen"
+    link: "https://https://daten.odis-berlin.de/archive/radverkehrsmengen"
 # if the post had a counterpart on the old site add these tags
 # for redirecting it
 redirect_from:
@@ -47,7 +47,7 @@ redirect_from:
 ---
 
 <p>
-    Seit 2015 erfasst die Berliner Senatsverwaltung den Radverkehr in der Stadt durch automatisierte <a href="https://www.stadtentwicklung.berlin.de/aktuell/pressebox/archiv_volltext.shtml?arch_1609/nachricht6200.html">Zählstellen</a>. Pünktlich zu unserem <a href="https://www.technologiestiftung-berlin.de/de/veranstaltungen/beitrag/radverkehr-40/Fahrrad-Meetup">Radverkehrs-Meetup</a> haben wir die Daten der insgesamt 26 Zählstellen aggregiert und aufbereitet (die Rohdaten finden sich <a href="https://data.technologiestiftung-berlin.de/dataset/radverkehrsmengen">hier</a>)
+    Seit 2015 erfasst die Berliner Senatsverwaltung den Radverkehr in der Stadt durch automatisierte <a href="https://www.stadtentwicklung.berlin.de/aktuell/pressebox/archiv_volltext.shtml?arch_1609/nachricht6200.html">Zählstellen</a>. Pünktlich zu unserem <a href="https://www.technologiestiftung-berlin.de/de/veranstaltungen/beitrag/radverkehr-40/Fahrrad-Meetup">Radverkehrs-Meetup</a> haben wir die Daten der insgesamt 26 Zählstellen aggregiert und aufbereitet (die Rohdaten finden sich <a href="https://daten.odis-berlin.de/archive/radverkehrsmengen">hier</a>)
 </p>
 
 <p>

--- a/source/projects/bikerides/en/index.html
+++ b/source/projects/bikerides/en/index.html
@@ -39,7 +39,7 @@ assets:
 
 materialsIncluded:
   - name: "Dataset"
-    link: "https://data.technologiestiftung-berlin.de/dataset/radverkehrsmengen"
+    link: "https://daten.odis-berlin.de/archive/radverkehrsmengen"
 # if the post had a counterpart on the old site add these tags
 # for redirecting it
 redirect_from:

--- a/source/projects/datadive-cycling/de/index.md
+++ b/source/projects/datadive-cycling/de/index.md
@@ -34,7 +34,7 @@ Eintauchen in Radverkehrsdaten
 
 Radverkehr ist ein Thema, das viele Berliner\*innen bewegt, zumal der Bedarf nach besserer Radinfrastruktur offenkundig ist. Im Juni hat das Berliner Abgeordnetenhaus ein Mobilitätsgesetz verabschiedet, in dem auch der Ausbau der städtischen Radinfrakstruktur eine wichtige Rolle spielt.
 
-In den nachfolgenden Abschnitten versuchen wir, die jeweils wesentlichen Datensätze zu benennen und wo immer möglich auch zu verlinken. Viele der Datensätze stammen aus dem [FIS-Broker](https://www.stadtentwicklung.berlin.de/geoinformation/fis-broker/), dem zentralen Geodatenportal des Landes Berlin. Theoretisch sind die meisten Datensätze des FIS-Brokers frei zugänglich. In der Praxis ist die Plattform leider nicht sehr benutzerfreundlich, was vor allem unerfahrene Anwender\*innen vor Probleme stellt. Um eine leichtere Weiterverwendung zu ermöglichen, haben wir die wichtigsten Datensätze in gängige Formate (GeoJSON, KML, etc.) konvertiert und bieten sie über unsere [Daten-Seite](https://data.technologiestiftung-berlin.de) zum Download an. Wir arbeiten übrigens gerade an einem Werkzeug, um diese Konvertierung zukünftig zu automatisieren – dazu bald mehr.
+In den nachfolgenden Abschnitten versuchen wir, die jeweils wesentlichen Datensätze zu benennen und wo immer möglich auch zu verlinken. Viele der Datensätze stammen aus dem [FIS-Broker](https://www.stadtentwicklung.berlin.de/geoinformation/fis-broker/), dem zentralen Geodatenportal des Landes Berlin. Theoretisch sind die meisten Datensätze des FIS-Brokers frei zugänglich. In der Praxis ist die Plattform leider nicht sehr benutzerfreundlich, was vor allem unerfahrene Anwender\*innen vor Probleme stellt. Um eine leichtere Weiterverwendung zu ermöglichen, haben wir die wichtigsten Datensätze in gängige Formate (GeoJSON, KML, etc.) konvertiert und bieten sie über unsere [Daten-Seite](https://daten.odis-berlin.de) zum Download an. Wir arbeiten übrigens gerade an einem Werkzeug, um diese Konvertierung zukünftig zu automatisieren – dazu bald mehr.
 
 Falls ihr Fehler entdeckt, Verbesserungs- oder Ergänzungsvorschläge habt oder weitere relevante Datenquellen zum Thema kennt, meldet euch gerne unter [boeck@technologiestiftung-berlin.de](mailto:boeck@technologiestiftung-berlin.de)
 
@@ -49,7 +49,7 @@ Radinfrastrukturdaten
 Geodaten zu bestehenden Radwegen sind im FIS-Broker vorhanden. Die aktuelle Karte wurde zuletzt im April 2017 aktualisiert; Zum Aktualisierungszyklus sind keine Informationen vorhanden. Die Karte verzeichnet Radwege, Radfahrstreifen, Schutzstreifen und Bussonderfahrstreifen.
 
 * [Radverkehrsanlagen (FIS-Broker-Karte)](https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=wmsk_radverkehrsanlagen@senstadt&bbox=383204,5818380,393456,5824453)
-* [Geodaten zu Radverkehrsanlagen (Lab-Datenportal)](https://data.technologiestiftung-berlin.de/dataset/radverkehrsanlagen)
+* [Geodaten zu Radverkehrsanlagen (Lab-Datenportal)](https://daten.odis-berlin.de/archive/radverkehrsanlagen)
 
 ### Radwege – geplant
 
@@ -99,7 +99,7 @@ Natürlich sind auch allgemeine Daten zum Berliner Straßennetz für Radfahrende
 
 *   [Übergeordnetes Straßennetz (FIS-Broker-Karte)](https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=showMap&mapId=verkehr_strnetz@senstadt)
 *   [Detailnetz Berlin (FIS-Broker-Karte)](https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=k_vms_detailnetz_wms_spatial@senstadt)
-*  [Geodaten zum Straßennetz (Lab-Datenportal)](https://data.technologiestiftung-berlin.de/dataset/detailnetz_strassenabschnitte)
+*  [Geodaten zum Straßennetz (Lab-Datenportal)](https://daten.odis-berlin.de/dataset/detailnetz_strassenabschnitte)
 
 ### Straßenbau
 
@@ -124,7 +124,7 @@ Viele Bezirke haben eigene Feedback-Systeme für die Meldung von Straßenschäde
 "Lichtsignalanlagen" ist Verwaltungsdeutsch für Ampeln. Fahrradfahrer, die eine effiziente Route bevorzugen, wollen eventuell Straßen mit vielen Ampeln vermeiden. Im FIS-Broker findet sich eine Karte mit den Standorten von Ampeln in der Stadt.
 
 *   [Lichtsignalanlagen (FIS-Broker-Karte)](https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=lsa@senstadt&bbox=384259,5817306,395263,5823841)
-*   [Geodaten zu Lichtsignalanlagen (Lab-Datenportal)](https://data.technologiestiftung-berlin.de/dataset/lichtsignalanlagen)
+*   [Geodaten zu Lichtsignalanlagen (Lab-Datenportal)](https://daten.odis-berlin.de/archive/lichtsignalanlagen)
 
 ### Standorte und Anzahl von Fahrradabstellplätzen
 
@@ -173,7 +173,7 @@ Eine weitere Methode, um Rückschlüsse auf Fahrradfahrer in der Stadt zu erhalt
 Das Autoverkehrsaufkommen einer Straße hat auch Auswirkungen auf die Sicherheit des Radverkehrs – viele Fahrradfahrer nutzen lieber wenig befahrene Straßen, wenn sie denn eine Wahl haben. Im FIS-Broker findet sich eine Karte mit Verkehrsmengen von Kraftfahrzeugen auf Berliner Straßen. Die aktuellste Karte wurde 2017 veröffentlicht, die Daten stammen aber eigentlich aus 2014. [Ein Bericht](https://www.stadtentwicklung.berlin.de/umwelt/umweltatlas/id701.htm) von der Senatsverwaltung für Umwelt, Verkehr und Klimaschutz erklärt, wie die Daten erhoben und aufbereitet werden.
 
 *   [Verkehrsmengen 2014 (FIS-Broker-Karte)](https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=wmsk_07_01verkmeng2014@senstadt&bbox=388207,5818680,395085,5822381)
-*   [Geodaten zu Verkehrsmengen (Lab-Datenportal)](https://data.technologiestiftung-berlin.de/dataset/verkehrsmengen)
+*   [Geodaten zu Verkehrsmengen (Lab-Datenportal)](https://daten.odis-berlin.de/archive/verkehrsmengen)
 
 Sonstiges
 ---------

--- a/source/projects/datadive-cycling/en/index.md
+++ b/source/projects/datadive-cycling/en/index.md
@@ -33,7 +33,7 @@ Diving into bicycle-related data
 
 To begin this series, we have decided to look at the subject of bicycle-related data. This has always been a popular topic in Berlin, where demand for more and improved bike infrastructure continues to mount. Most recently, a “mobility law” (Mobilitätsgesetz) was passed at the end of June of this year; it included specific provisions for how bicycle infrastructure should be expanded in the city.
 
-In the below sections, we list the key datasets needed to form a comprehensive overview of what the status quo of cycling in Berlin is. One general note: several of the datasets below exist in the FIS-Broker, Berlin’s main repository for geospatial data. In theory most data in the FIS-Broker is open data that can be downloaded and reused via a WFS server; in practice, the platform is extremely challenging and unintuitive to use and extracting data out of it is not trivial. To better enable the re-use of this open data, the Technologiestiftung Lab has extracted some of the core geospatial datasets mentioned here and made them available via our [data portal](https://data.technologiestiftung-berlin.de/en) in a variety of common data formats (e.g., GeoJSON, KML, etc.) The Lab is also working on tools to make it easier for FIS-Broker data to be extracted and used.
+In the below sections, we list the key datasets needed to form a comprehensive overview of what the status quo of cycling in Berlin is. One general note: several of the datasets below exist in the FIS-Broker, Berlin’s main repository for geospatial data. In theory most data in the FIS-Broker is open data that can be downloaded and reused via a WFS server; in practice, the platform is extremely challenging and unintuitive to use and extracting data out of it is not trivial. To better enable the re-use of this open data, the Technologiestiftung Lab has extracted some of the core geospatial datasets mentioned here and made them available via our [data portal](https://daten.odis-berlin.de/en) in a variety of common data formats (e.g., GeoJSON, KML, etc.) The Lab is also working on tools to make it easier for FIS-Broker data to be extracted and used.
 
 If you notice information here that seems to be incorrect, or if you are aware of relevant data sources that we did not identify, please feel free to reach out to [boeck@technologiestiftung-berlin.de](mailto:boeck@technologiestiftung-berlin.de) with corrections or suggested updates.
 
@@ -48,7 +48,7 @@ Bike infrastructure data
 Geospatial data for existing bike lanes can be found via the FIS-Broker. The current map was last updated in April 2017; no information is provided as to how regularly it is updated. The map includes geospatial data for the locations of bike paths (Radwege), designated bike lanes (Radfahrstreifen), advisory bike lanes (Schutzstreifen), and bus lanes (Bussonderfahrstreifen).
 
 *   [Map of existing bicycle infrastructure (FIS-Broker map)](https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=wmsk_radverkehrsanlagen@senstadt&bbox=383204,5818380,393456,5824453)
-*   [Geospatial data available for download via the Lab data portal](https://data.technologiestiftung-berlin.de/dataset/radverkehrsanlagen)
+*   [Geospatial data available for download via the Lab data portal](https://daten.odis-berlin.de/archive/radverkehrsanlagen)
 
 ### Bike lanes – planned
 
@@ -121,7 +121,7 @@ Many Bezirke also have their own feedback mechanisms for reporting damaged roads
 Bike riders concerned with choosing the most efficient routing possible may want to avoid roads with a lot of traffic lights. There is a map in the FIS-Broker which indicates the location of traffic lights (Lichtsignalanlagen) across the city.
 
 *   [Location of traffic lights (FIS-Broker map)](https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=lsa@senstadt&bbox=384259,5817306,395263,5823841)
-*   [Geospatial data available for download via the Lab data portal](https://data.technologiestiftung-berlin.de/dataset/lichtsignalanlagen/en)
+*   [Geospatial data available for download via the Lab data portal](https://daten.odis-berlin.de/archive/lichtsignalanlagen/en)
 
 ### Location and quantity of bike stands
 
@@ -168,7 +168,7 @@ A related metric for gauging ridership is data on the number of bicycle tickets 
 The volume of traffic on a given road naturally has a predictable impact on whether that road is suitable or at least ideal for bike riders – many riders would probably prefer to travel along less busy streets, if such adjustments can be made without sacrificing route efficiency. Berlin’s FIS-Broker contains a map of automobile traffic volume (encompassing all types of motorized traffic: cars, trucks, motorcycles, etc.). The current map was released in 2017, though its actual data is based on numbers observed in 2014. [A report (available in English)](https://www.stadtentwicklung.berlin.de/umwelt/umweltatlas/eid701.htm) from the Senatsverwaltung for Urban Development and Housing accompanying the map provides more information on the data, including how it was gathered and prepared.
 
 *   [Map of motorized traffic volume (FIS-Broker map)](https://fbinter.stadt-berlin.de/fb/index.jsp?loginkey=zoomStart&mapId=wmsk_07_01verkmeng2014@senstadt&bbox=388207,5818680,395085,5822381)
-*   [Geospatial data available for download via the Lab data portal](https://data.technologiestiftung-berlin.de/dataset/verkehrsmengen)
+*   [Geospatial data available for download via the Lab data portal](https://daten.odis-berlin.de/archive/verkehrsmengen)
 
 Miscellaneous
 -------------

--- a/source/projects/rueckblick/de/index.md
+++ b/source/projects/rueckblick/de/index.md
@@ -73,7 +73,7 @@ Bei der Ausstellung [„CityVis“](https://cityvis.io/exhibition.php) präsenti
 
 {% include macro-image-section-markdown.html src="../images/AR-CityVis.jpg" caption="Neue Layer auf alten Stadtmodellen" %}
 
-Ebenfalls ein Dauerbrenner: Unser eigenes kleines [Geodatenportal](https://data.technologiestiftung-berlin.de/), auf dem wir ausgewählte offene Datensätze nutzerfreundlich aufbereitet zum Download anbieten.
+Ebenfalls ein Dauerbrenner: Unser eigenes kleines [Geodatenportal](https://daten.odis-berlin.de/), auf dem wir ausgewählte offene Datensätze nutzerfreundlich aufbereitet zum Download anbieten.
 
 {% include macro-image-section-markdown.html src="../images/portal.jpg" caption="Offene Daten für alle" %}
 

--- a/source/projects/rueckblick/en/index.md
+++ b/source/projects/rueckblick/en/index.md
@@ -69,7 +69,7 @@ At the [„CityVis“](https://cityvis.io/exhibition.php) exhibition, we present
 
 {% include macro-image-section-markdown.html src="../images/AR-CityVis.jpg" caption="New layers atop an old city model" %}
 
-Also still accessible – and still well-used: our humble [geospatial data portal](https://data.technologiestiftung-berlin.de/en), where we make some of Berlin's most useful geospatial datasets available to download in common, easy-to-use formats.
+Also still accessible – and still well-used: our humble [geospatial data portal](https://daten.odis-berlin.de/en), where we make some of Berlin's most useful geospatial datasets available to download in common, easy-to-use formats.
 
 {% include macro-image-section-markdown.html src="../images/portal.jpg" caption="Open data for all" %}
 

--- a/source/projects/spatial-units/de/index.html
+++ b/source/projects/spatial-units/de/index.html
@@ -79,28 +79,28 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/bezirksgrenzen">
+            <a href="https://daten.odis-berlin.de/de/dataset/bezirksgrenzen">
                 <span class="download-icon"></span>
                 <span class="download-title">Bezirksgrenzen</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/lor_prognoseraeume">
+            <a href="https://daten.odis-berlin.de/de/dataset/lor_prognoseraeume">
                 <span class="download-icon"></span>
                 <span class="download-title">Prognoseräume</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/lor_bezirksregionen">
+            <a href="https://daten.odis-berlin.de/de/dataset/lor_bezirksregionen">
                 <span class="download-icon"></span>
                 <span class="download-title">Bezirksregionen</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/lor_planungsgraeume">
+            <a href="https://daten.odis-berlin.de/de/dataset/lor_planungsgraeume">
                 <span class="download-icon"></span>
                 <span class="download-title">Planungsräume</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
@@ -119,14 +119,14 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/verkehrszellen">
+            <a href="https://daten.odis-berlin.de/de/dataset/verkehrszellen">
                 <span class="download-icon"></span>
                 <span class="download-title">Verkehrszellen</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/teil_verkehrszellen">
+            <a href="https://daten.odis-berlin.de/de/dataset/teil_verkehrszellen">
                 <span class="download-icon"></span>
                 <span class="download-title">Teilverkehrszellen</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
@@ -144,14 +144,14 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/flure">
+            <a href="https://daten.odis-berlin.de/de/dataset/flure">
                 <span class="download-icon"></span>
                 <span class="download-title">Flure</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/flurstuecke">
+            <a href="https://daten.odis-berlin.de/de/dataset/flurstuecke">
                 <span class="download-icon"></span>
                 <span class="download-title">Flurstücke</span><br />
                 <span class="download-subtitle">Postgres, GeoJSON, Shapefile</span>
@@ -170,14 +170,14 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/plz">
+            <a href="https://daten.odis-berlin.de/de/dataset/plz">
                 <span class="download-icon"></span>
                 <span class="download-title">Postleitzahlen</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/ortsteile">
+            <a href="https://daten.odis-berlin.de/de/dataset/ortsteile">
                 <span class="download-icon"></span>
                 <span class="download-title">Ortsteile</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
@@ -194,21 +194,21 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/strassenflaechen">
+            <a href="https://daten.odis-berlin.de/de/dataset/strassenflaechen">
                 <span class="download-icon"></span>
                 <span class="download-title">Straßen</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/gebaeude">
+            <a href="https://daten.odis-berlin.de/de/dataset/gebaeude">
                 <span class="download-icon"></span>
                 <span class="download-title">Gebäude</span><br />
                 <span class="download-subtitle">Postgres, GeoJSON, Shapefile</span>
             </a>
         </li>
         <li style="clear:both;">
-            <a href="https://data.technologiestiftung-berlin.de/dataset/blockflaechen">
+            <a href="https://daten.odis-berlin.de/de/dataset/blockflaechen">
                 <span class="download-icon"></span>
                 <span class="download-title">Block- und Teilblockflächen</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
@@ -218,4 +218,4 @@ redirect_from:
 </div>
 
 <p>Wer mehr erfahren möchte, das Amt für Statistik Berlin Brandenburg hat 2012 einen kleinen <a href="https://www.statistik-berlin-brandenburg.de/publikationen/aufsaetze/2012/HZ_201201-06.pdf">Bericht</a> zu den verschiedenen räumlichen und statistischen Einheiten geschrieben.</p>
-<p>Alle in dieser Übersicht aufgeführten Datensätzen finden Sie auf unserer <a href="https://data.technologiestiftung-berlin.de">Datenseite</a> in vielen gängigen Formaten direkt zum Herunterladen. Darüber hinaus finden Sie die Daten natürlich auch im Berliner <a href="http://fbinter.stadt-berlin.de/fb/index.jsp">FIS-Broker</a> als WFS-Downloads.</p>
+<p>Alle in dieser Übersicht aufgeführten Datensätzen finden Sie auf unserer <a href="https://daten.odis-berlin.de">Datenseite</a> in vielen gängigen Formaten direkt zum Herunterladen. Darüber hinaus finden Sie die Daten natürlich auch im Berliner <a href="http://fbinter.stadt-berlin.de/fb/index.jsp">FIS-Broker</a> als WFS-Downloads.</p>

--- a/source/projects/spatial-units/en/index.html
+++ b/source/projects/spatial-units/en/index.html
@@ -80,28 +80,28 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/bezirksgrenzen/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/bezirksgrenzen>
                 <span class="download-icon"></span>
                 <span class="download-title">Districts</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/lor_prognoseraeume/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/lor_prognoseraeume>
                 <span class="download-icon"></span>
                 <span class="download-title">Prediction areas</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/lor_bezirksregionen/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/lor_bezirksregionen>
                 <span class="download-icon"></span>
                 <span class="download-title">District areas</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/lor_planungsgraeume/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/lor_planungsgraeume>
                 <span class="download-icon"></span>
                 <span class="download-title">Planning areas</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
@@ -120,14 +120,14 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/verkehrszellen/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/verkehrszellen>
                 <span class="download-icon"></span>
                 <span class="download-title">Traffic cells</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/teil_verkehrszellen/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/teil_verkehrszellen>
                 <span class="download-icon"></span>
                 <span class="download-title">Sub traffic cells</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
@@ -145,14 +145,14 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/flure/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/flure>
                 <span class="download-icon"></span>
                 <span class="download-title">Corridors</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/flurstuecke/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/flurstuecke>
                 <span class="download-icon"></span>
                 <span class="download-title">Corridor pieces</span><br />
                 <span class="download-subtitle">Postgres, GeoJSON, Shapefile</span>
@@ -171,14 +171,14 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/plz/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/plz>
                 <span class="download-icon"></span>
                 <span class="download-title">Postcodes</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/ortsteile/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/ortsteile>
                 <span class="download-icon"></span>
                 <span class="download-title">City parts</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
@@ -195,21 +195,21 @@ redirect_from:
 <div class="container p-bottom">
     <ul class="download-list">
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/strassenflaechen/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/strassenflaechen>
                 <span class="download-icon"></span>
                 <span class="download-title">Roads</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
             </a>
         </li>
         <li>
-            <a href="https://data.technologiestiftung-berlin.de/dataset/gebaeude/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/gebaeude>
                 <span class="download-icon"></span>
                 <span class="download-title">Buildings</span><br />
                 <span class="download-subtitle">Postgres, GeoJSON, Shapefile</span>
             </a>
         </li>
         <li style="clear:both;">
-            <a href="https://data.technologiestiftung-berlin.de/dataset/blockflaechen/en">
+            <a href="https://daten.odis-berlin.de/en/dataset/blockflaechen>
                 <span class="download-icon"></span>
                 <span class="download-title">Blocks- and Sub-blocks</span><br />
                 <span class="download-subtitle">CSV, GeoJSON, KML, SQLite, Postgres, gml, Shapefile</span>
@@ -219,4 +219,4 @@ redirect_from:
 </div>
 
 <p>If you are interested and want to learn more about Berlin's spatial and statistical units, Berlin and Brandenburg's office for statistics wrote an <a href="https://www.statistik-berlin-brandenburg.de/publikationen/aufsaetze/2012/HZ_201201-06.pdf">article</a> (only in German) with further details.</p>
-<p>All spatial units mentioned in this overview are available for download on our <a href="https://data.technologiestiftung-berlin.de">data site</a> in various formats. The original data sets can be downloaded from Berlin's <a href="http://fbinter.stadt-berlin.de/fb/index.jsp">FIS-Broker</a> as WFS-sources.</p>
+<p>All spatial units mentioned in this overview are available for download on our <a href="https://daten.odis-berlin.de/en">data site</a> in various formats. The original data sets can be downloaded from Berlin's <a href="http://fbinter.stadt-berlin.de/fb/index.jsp">FIS-Broker</a> as WFS-sources.</p>


### PR DESCRIPTION
The data portal now runs under a ODIS-URL (daten.odis-berlin.de). Therefore I removed the link to the old portal in the navigation of the Ideation and Prototyping page. There were also many links to the portal in various blog posts. I changed all of them to the new portal.

The old URL of the portal daten.technologiestiftung-berlin.de can be deactivated as soon as this branch is merged.